### PR TITLE
Force input wavelengths to transmission models to be sorted

### DIFF
--- a/pwv_kpno/__init__.py
+++ b/pwv_kpno/__init__.py
@@ -57,6 +57,6 @@ __credits__ = [
 ]
 
 __license__ = 'GPL V3'
-__version__ = '2.0.0.dev5'
+__version__ = '2.0.0.dev6'
 __email__ = 'djperrefort@pitt.edu'
 __status__ = 'Release'

--- a/pwv_kpno/transmission.py
+++ b/pwv_kpno/transmission.py
@@ -96,8 +96,8 @@ def bin_transmission(transmission: ArrayLike, resolution: float, wave: ArrayLike
     # at the given resolution
     half_res = resolution / 2
     bins = np.arange(
-        min(wave) - half_res,
-        max(wave) + half_res + resolution,
+        wave[0] - half_res,
+        wave[-1] + half_res + resolution,
         resolution)
 
     # noinspection PyArgumentEqualDefault
@@ -160,8 +160,11 @@ class TransmissionModel(VectorizedCall):
             samp_transmission: 2D array with transmission values for each PWV and wavelength
         """
 
+        if not np.all(np.diff(samp_wave) >= 0):
+            raise ValueError('Input wavelengths must be sorted.')
+
         self.samp_pwv = samp_pwv
-        self.samp_wave = samp_wave
+        self.samp_wave = np.array(samp_wave)
         self.samp_transmission = samp_transmission
         self.norm_pwv = norm_pwv
         self.eff_exp = eff_exp
@@ -240,7 +243,10 @@ class CrossSectionTransmission(VectorizedCall):
             cross_sections: 1D array with cross sections in cm squared
         """
 
-        self.samp_wave = samp_wave
+        if not np.all(np.diff(samp_wave) >= 0):
+            raise ValueError('Input wavelengths must be sorted.')
+
+        self.samp_wave = np.array(samp_wave)
         self.cross_sections = cross_sections
 
     @classmethod


### PR DESCRIPTION
A 60% runtime improvement was achieved by sorting input arrays at instantiation, thus allowing calls to `min` and `max` to be replaced with indexing operations. 