### PR TITLE
Update to astropy.modeling.models for BlackBody

### DIFF
--- a/pwv_kpno/blackbody_with_atm.py
+++ b/pwv_kpno/blackbody_with_atm.py
@@ -52,7 +52,7 @@ from typing import Union
 import numpy as np
 from astropy import units as u
 from astropy.constants import c
-from astropy.modeling.blackbody import blackbody_lambda
+from astropy.modeling.models import BlackBody
 
 from pwv_kpno.pwv_atm import trans_for_pwv
 
@@ -76,8 +76,9 @@ def sed(temp: float,
          An array of flux values in units of ergs / (angstrom * cm2 * s * sr)
      """
 
-    # blackbody_lambda returns ergs / (angstrom * cm2 * s * sr)
-    bb_sed = blackbody_lambda(wavelengths, temp).value
+    # BlackBody(u.K)(u.AA) returns a Quantity with default ergs / (angstrom * cm2 * s * sr)
+    bb = BlackBody(temp * u.K)
+    bb_sed = bb(wavelengths * u.AA)
 
     if pwv > 0:
         transmission = trans_for_pwv(pwv, bins=bins)

--- a/pwv_kpno/blackbody_with_atm.py
+++ b/pwv_kpno/blackbody_with_atm.py
@@ -51,7 +51,7 @@ from typing import Union
 
 import numpy as np
 from astropy import units as u
-from astropy.constants import c
+import astropy.constants as c
 from astropy.modeling.models import BlackBody
 
 from pwv_kpno.pwv_atm import trans_for_pwv
@@ -124,13 +124,10 @@ def magnitude(
         flux_pwv *= band[1]
 
     # We introduce units here to make dimensional analysis easier
-    lambda_over_c = (np.median(wavelengths) * u.AA) / c
-    flux_pwv *= u.erg / (u.AA * u.cm * u.cm * u.s * u.sr)
     flux_pwv *= 2 * np.pi * u.sr  # integrate over angular coordinates
-    flux_pwv *= lambda_over_c.cgs
 
     zero_point = (3631 * u.jansky).to(u.erg / u.cm ** 2)
-    int_flux = np.trapz(x=wavelengths, y=flux_pwv) * u.AA
+    int_flux = np.trapz(x=wavelengths, y=flux_pwv)
     mag = -2.5 * np.log10(int_flux / zero_point)
 
     return mag.value

--- a/tests/test_blackbody_with_atm.py
+++ b/tests/test_blackbody_with_atm.py
@@ -21,11 +21,10 @@
 from unittest import TestCase
 
 import numpy as np
-from astropy.modeling.blackbody import blackbody_lambda
+from astropy.modeling.models import BlackBody
+import astropy.units as u
 
-from pwv_kpno.blackbody_with_atm import magnitude
-from pwv_kpno.blackbody_with_atm import sed
-from pwv_kpno.blackbody_with_atm import zp_bias
+from pwv_kpno.blackbody_with_atm import magnitude, sed, zp_bias
 
 
 class BlackbodySED(TestCase):
@@ -40,7 +39,8 @@ class BlackbodySED(TestCase):
 
         returned_sed = sed(self.temp, self.wavelengths, 0)
 
-        expected_sed = blackbody_lambda(self.wavelengths, self.temp).value
+        bb = BlackBody(self.temp * u.K)
+        expected_sed = bb(self.wavelengths * u.AA)
 
         sed_is_same = np.all(np.equal(returned_sed, expected_sed))
         self.assertTrue(sed_is_same,

--- a/tests/test_pwv_atm.py
+++ b/tests/test_pwv_atm.py
@@ -176,14 +176,14 @@ class PwvDate(TestCase):
         self.assertRaises(ValueError,
                           pwv_atm._pwv_date,
                           one_day_start,
-                          1,
-                          mock_model)
+                          format="unix",
+                          test_model=mock_model)
 
         self.assertRaises(ValueError,
                           pwv_atm._pwv_date,
                           three_day_start,
-                          1,
-                          mock_model)
+                          format="unix",
+                          test_model=mock_model)
 
 
 class TransmissionErrors(TestCase):


### PR DESCRIPTION
AstroPy modeling blackbody became generalized into `astropy.modeling.models` a while back.

This update adapts to the new model, touches up the units, and updates tests.